### PR TITLE
feat: migrate packages to ESM

### DIFF
--- a/packages/create-deck/cli.js
+++ b/packages/create-deck/cli.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
-const fs = require('fs')
-const path = require('path')
-const meow = require('meow')
-const chalk = require('chalk')
-const initit = require('initit')
+import chalk from 'chalk'
+import initit from 'initit'
+import { createRequire } from 'module'
+
+const cjs = createRequire(import.meta.url)
+const meow = cjs('meow')
 
 const logo = chalk.magenta('[mdx-deck]')
 const log = (...args) => {

--- a/packages/create-deck/package.json
+++ b/packages/create-deck/package.json
@@ -2,6 +2,7 @@
   "name": "create-deck",
   "version": "4.0.0",
   "description": "Create mdx-deck presentations",
+  "type": "module",
   "bin": {
     "create-deck": "cli.js"
   },

--- a/packages/gatsby-plugin/gatsby-config.js
+++ b/packages/gatsby-plugin/gatsby-config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   plugins: [
     'gatsby-plugin-react-helmet',
   ],

--- a/packages/gatsby-plugin/gatsby-node.js
+++ b/packages/gatsby-plugin/gatsby-node.js
@@ -1,13 +1,19 @@
-const fs = require('fs')
-const path = require('path')
-const { createPath, validatePath } = require('gatsby-page-utils')
+import fs from 'fs'
+import path from 'path'
+import remarkImages from 'remark-images'
+import remarkUnwrapImages from 'remark-unwrap-images'
+import remarkEmoji from 'remark-emoji'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
 const remarkPlugins = [
-  require('remark-images'),
-  require('remark-unwrap-images'),
-  require('remark-emoji'),
+  remarkImages,
+  remarkUnwrapImages,
+  remarkEmoji,
 ]
 
-exports.onPreBootstrap = ({}, opts = {}) => {
+export const onPreBootstrap = ({}, opts = {}) => {
   opts.dirname = opts.dirname || __dirname
   const staticSourceDir = path.join(opts.dirname, 'static')
   const hasStaticDir = fs.existsSync(staticSourceDir)
@@ -23,7 +29,7 @@ exports.onPreBootstrap = ({}, opts = {}) => {
   }
 }
 
-exports.onCreateWebpackConfig = ({
+export const onCreateWebpackConfig = ({
   stage,
   rules,
   loaders,
@@ -50,9 +56,9 @@ exports.onCreateWebpackConfig = ({
   })
 }
 
-exports.resolvableExtensions = () => ['.mdx']
+export const resolvableExtensions = () => ['.mdx']
 
-exports.createPages = ({
+export const createPages = ({
   actions,
 }, {
   path: source,

--- a/packages/gatsby-plugin/package.json
+++ b/packages/gatsby-plugin/package.json
@@ -2,6 +2,7 @@
   "name": "@mdx-deck/gatsby-plugin",
   "version": "4.1.1",
   "main": "index.js",
+  "type": "module",
   "author": "Brent Jackson",
   "license": "MIT",
   "repository": "github:jxnblk/mdx-deck",

--- a/packages/gatsby-theme/gatsby-config.js
+++ b/packages/gatsby-theme/gatsby-config.js
@@ -1,6 +1,12 @@
+import remarkUnwrapImages from 'remark-unwrap-images'
+import remarkEmoji from 'remark-emoji'
+import { fileURLToPath } from 'url'
+import { dirname } from 'path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
 const IS_LOCAL = process.cwd() === __dirname
 
-const remarkPlugins = [require('remark-unwrap-images'), require('remark-emoji')]
+const remarkPlugins = [remarkUnwrapImages, remarkEmoji]
 const gatsbyRemarkPlugins = [`gatsby-remark-import-code`]
 
 const config = (opts = {}) => {
@@ -36,4 +42,4 @@ const config = (opts = {}) => {
   }
 }
 
-module.exports = IS_LOCAL ? config() : config
+export default IS_LOCAL ? config() : config

--- a/packages/gatsby-theme/gatsby-node.js
+++ b/packages/gatsby-theme/gatsby-node.js
@@ -1,9 +1,12 @@
 // based on gatsby-theme-blog
-const fs = require(`fs`)
-const path = require(`path`)
-const mkdirp = require(`mkdirp`)
-const Debug = require(`debug`)
-const pkg = require('./package.json')
+import fs from 'fs'
+import path from 'path'
+import mkdirp from 'mkdirp'
+import Debug from 'debug'
+import { createRequire } from 'module'
+import pkg from './package.json' with { type: 'json' }
+
+const require = createRequire(import.meta.url)
 
 const debug = Debug(pkg.name)
 
@@ -13,7 +16,7 @@ let contentPath
 const DeckTemplate = require.resolve(`./src/templates/deck`)
 const DecksTemplate = require.resolve(`./src/templates/decks`)
 
-exports.onPreBootstrap = ({ store }, opts = {}) => {
+export const onPreBootstrap = ({ store }, opts = {}) => {
   const { program } = store.getState()
 
   basePath = opts.basePath || `/`
@@ -49,7 +52,7 @@ const resolveTitle = async (...args) => {
   return first.value || ''
 }
 
-exports.createSchemaCustomization = ({ actions, schema }) => {
+export const createSchemaCustomization = ({ actions, schema }) => {
   actions.createTypes(
     schema.buildObjectType({
       name: `Deck`,
@@ -72,7 +75,7 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
   )
 }
 
-exports.createPages = async ({ graphql, actions, reporter, pathPrefix }) => {
+export const createPages = async ({ graphql, actions, reporter, pathPrefix }) => {
   const { createPage } = actions
 
   const result = await graphql(`
@@ -157,7 +160,7 @@ exports.createPages = async ({ graphql, actions, reporter, pathPrefix }) => {
   })
 }
 
-exports.onCreateNode = ({
+export const onCreateNode = ({
   node,
   actions,
   getNode,
@@ -197,7 +200,7 @@ exports.onCreateNode = ({
   createParentChildLink({ parent: fileNode, child: getNode(id) })
 }
 
-exports.onCreateDevServer = ({ app }) => {
+export const onCreateDevServer = ({ app }) => {
   if (typeof process.send !== 'function') return
   process.send({
     mdxDeck: true,

--- a/packages/gatsby-theme/package.json
+++ b/packages/gatsby-theme/package.json
@@ -2,6 +2,7 @@
   "name": "gatsby-theme-mdx-deck",
   "version": "4.1.0",
   "main": "index.js",
+  "type": "module",
   "license": "MIT",
   "scripts": {
     "start": "gatsby develop",

--- a/packages/mdx-deck/cli.js
+++ b/packages/mdx-deck/cli.js
@@ -1,10 +1,16 @@
 #!/usr/bin/env node
-const path = require('path')
-const meow = require('meow')
-const execa = require('execa')
-const chalk = require('chalk')
-const fs = require('fs-extra')
-const pkg = require('./package.json')
+import path from 'path'
+import execa from 'execa'
+import chalk from 'chalk'
+import fs from 'fs-extra'
+import pkg from './package.json' with { type: 'json' }
+import { fileURLToPath } from 'url'
+import { createRequire } from 'module'
+
+const cjs = createRequire(import.meta.url)
+const meow = cjs('meow')
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const log = (...args) => {
   console.log(chalk.green('[mdx-deck]'), ...args)
@@ -77,10 +83,10 @@ const gatsby = async (...args) => {
 switch (cmd) {
   case 'build':
     gatsby('build').then(() => {
-      const public = path.join(__dirname, 'public')
+      const publicDir = path.join(__dirname, 'public')
       const dist = path.join(process.cwd(), 'public')
-      if (public === dist) return
-      fs.copySync(public, dist)
+      if (publicDir === dist) return
+      fs.copySync(publicDir, dist)
     })
     break
   case 'dev':

--- a/packages/mdx-deck/gatsby-config.js
+++ b/packages/mdx-deck/gatsby-config.js
@@ -1,9 +1,9 @@
-const path = require('path')
+import path from 'path'
 
 const src = process.env.__SRC__
 const dirname = path.dirname(src)
 
-module.exports = {
+export default {
   plugins: [
     {
       resolve: '@mdx-deck/gatsby-plugin',

--- a/packages/mdx-deck/package.json
+++ b/packages/mdx-deck/package.json
@@ -6,6 +6,7 @@
     "mdx-deck": "./cli.js"
   },
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "start": "./cli.js hello.mdx",
     "build": "./cli.js build hello.mdx",

--- a/packages/starter/gatsby-config.js
+++ b/packages/starter/gatsby-config.js
@@ -1,3 +1,3 @@
-module.exports = {
+export default {
   plugins: ['gatsby-theme-mdx-deck'],
 }

--- a/packages/starter/package.json
+++ b/packages/starter/package.json
@@ -3,6 +3,7 @@
   "name": "@mdx-deck/gatsby-starter",
   "version": "4.1.0",
   "main": "index.js",
+  "type": "module",
   "license": "MIT",
   "scripts": {
     "start": "gatsby develop",

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -2,6 +2,7 @@
   "name": "@mdx-deck/themes",
   "version": "4.1.0",
   "main": "index.js",
+  "type": "module",
   "author": "Brent Jackson <jxnblk@gmail.com>",
   "license": "MIT",
   "dependencies": {

--- a/packages/website-pdf/cli.js
+++ b/packages/website-pdf/cli.js
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
-const path = require('path')
-const meow = require('meow')
+import generatePdf from './index.js'
+import { createRequire } from 'module'
+
+const cjs = createRequire(import.meta.url)
+const meow = cjs('meow')
 
 const cli = meow(
   `
@@ -51,7 +54,7 @@ const opts = Object.assign({}, cli.flags, {
   url,
 })
 
-require('./index')(opts)
+generatePdf(opts)
   .then(filename => {
     console.log(`saved PDF to`, filename)
     process.exit(0)

--- a/packages/website-pdf/index.js
+++ b/packages/website-pdf/index.js
@@ -1,8 +1,8 @@
-const path = require('path')
-const puppeteer = require('puppeteer-core')
-const mkdirp = require('mkdirp')
+import path from 'path'
+import puppeteer from 'puppeteer-core'
+import mkdirp from 'mkdirp'
 
-module.exports = async ({ url, outFile, width, height, sandbox }) => {
+export default async ({ url, outFile, width, height, sandbox }) => {
   if (!url) {
     throw new Error('URL is required for website-pdf')
   }

--- a/packages/website-pdf/package.json
+++ b/packages/website-pdf/package.json
@@ -4,6 +4,7 @@
   "author": "Brent Jackson <jxnblk@gmail.com>",
   "license": "MIT",
   "bin": "./cli.js",
+  "type": "module",
   "scripts": {
     "test": "./cli.js http://localhost:8000/print -o ../../docs/dist"
   },


### PR DESCRIPTION
## Summary
- declare packages as ES modules via `type: module`
- replace CommonJS `require`/`module.exports` with ESM `import`/`export`
- ensure CLIs still run under Node by using `createRequire`

## Testing
- `yarn test` *(fails: Command failed with exit code 1: gatsby develop --host localhost --port 8000 --open)*
- `node packages/create-deck/cli.js --help`
- `node packages/mdx-deck/cli.js --help`
- `node packages/website-pdf/cli.js --help`


------
https://chatgpt.com/codex/tasks/task_e_689389f670148321849d1564401386b1