### PR TITLE
chore: require Node 22 across workspaces

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -14,5 +14,8 @@
     "@emotion/styled": "^10.0.7",
     "mdx-deck": "^4.1.1",
     "styled-system": "^5.0.15"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/examples/aspect-ratio/package.json
+++ b/examples/aspect-ratio/package.json
@@ -9,5 +9,8 @@
   },
   "devDependencies": {
     "mdx-deck": "^4.1.1"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -9,5 +9,8 @@
   },
   "devDependencies": {
     "mdx-deck": "^4.1.1"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/examples/gatsby/package.json
+++ b/examples/gatsby/package.json
@@ -17,5 +17,8 @@
     "gatsby-theme-mdx-deck": "^4.1.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/examples/head/package.json
+++ b/examples/head/package.json
@@ -9,5 +9,8 @@
   },
   "devDependencies": {
     "mdx-deck": "^4.1.1"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/examples/header-footer/package.json
+++ b/examples/header-footer/package.json
@@ -9,5 +9,8 @@
   },
   "devDependencies": {
     "mdx-deck": "^4.1.1"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/examples/images/package.json
+++ b/examples/images/package.json
@@ -9,5 +9,8 @@
   },
   "devDependencies": {
     "mdx-deck": "^4.1.1"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/examples/layouts/package.json
+++ b/examples/layouts/package.json
@@ -9,5 +9,8 @@
   },
   "devDependencies": {
     "mdx-deck": "^4.1.1"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/examples/multiple/package.json
+++ b/examples/multiple/package.json
@@ -9,5 +9,8 @@
   },
   "devDependencies": {
     "mdx-deck": "^4.1.1"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/examples/prism/package.json
+++ b/examples/prism/package.json
@@ -9,5 +9,8 @@
   },
   "devDependencies": {
     "mdx-deck": "^4.1.1"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/examples/provider/package.json
+++ b/examples/provider/package.json
@@ -9,5 +9,8 @@
   },
   "devDependencies": {
     "mdx-deck": "^4.1.1"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/examples/steps/package.json
+++ b/examples/steps/package.json
@@ -9,5 +9,8 @@
   },
   "devDependencies": {
     "mdx-deck": "^4.1.1"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/examples/syntax-highlighting/package.json
+++ b/examples/syntax-highlighting/package.json
@@ -9,5 +9,8 @@
   },
   "devDependencies": {
     "mdx-deck": "^4.1.1"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/examples/themes/package.json
+++ b/examples/themes/package.json
@@ -9,5 +9,8 @@
   },
   "devDependencies": {
     "mdx-deck": "^4.1.1"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "cypress": "^14.5.3",
     "husky": "^9.1.7",
     "jest": "^29.7.0",
-    "jest-environment-jsdom": "^29.7.0",
     "jest-emotion": "^10.0.27",
+    "jest-environment-jsdom": "^29.7.0",
     "lerna": "^3.13.1",
     "lint-staged": "^10.0.4",
     "prettier": "^3.6.2",
@@ -68,5 +68,8 @@
       "prettier --write",
       "git add"
     ]
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/packages/create-deck/package.json
+++ b/packages/create-deck/package.json
@@ -3,9 +3,7 @@
   "version": "4.0.0",
   "description": "Create mdx-deck presentations",
   "type": "module",
-  "bin": {
-    "create-deck": "cli.js"
-  },
+  "bin": "cli.js",
   "author": "Brent Jackson",
   "license": "MIT",
   "dependencies": {
@@ -13,5 +11,8 @@
     "initit": "^1.0.0-2",
     "meow": "^6.0.0"
   },
-  "gitHead": "13d00b47780424cc3b52d38ad6f19e99d007c06a"
+  "gitHead": "13d00b47780424cc3b52d38ad6f19e99d007c06a",
+  "engines": {
+    "node": ">=22"
+  }
 }

--- a/packages/gatsby-plugin/package.json
+++ b/packages/gatsby-plugin/package.json
@@ -34,5 +34,8 @@
   "gitHead": "13d00b47780424cc3b52d38ad6f19e99d007c06a",
   "publishConfig": {
     "access": "public"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/packages/gatsby-theme/package.json
+++ b/packages/gatsby-theme/package.json
@@ -45,5 +45,8 @@
     "remark-unwrap-images": "^2.0.0",
     "theme-ui": "^0.3.1"
   },
-  "gitHead": "13d00b47780424cc3b52d38ad6f19e99d007c06a"
+  "gitHead": "13d00b47780424cc3b52d38ad6f19e99d007c06a",
+  "engines": {
+    "node": ">=22"
+  }
 }

--- a/packages/mdx-deck/README.md
+++ b/packages/mdx-deck/README.md
@@ -36,14 +36,15 @@ Award-winning React [MDX][]-based presentation decks
 
 ## Getting Started
 
+Requires Node.js v22 or higher.
+
 ```sh
 npm i -D mdx-deck
 ```
 
 Create an [MDX][] file and separate each slide with `---`.
 
-````mdx
-
+```mdx
 # Hello
 
 ---
@@ -53,8 +54,7 @@ Create an [MDX][] file and separate each slide with `---`.
 ---
 
 ## The End
-
-````
+```
 
 Add a run script to your `package.json` with the MDX Deck CLI
 pointing to the `.mdx` file to start the development server:
@@ -130,7 +130,7 @@ _Note: please check with version compatibility when using these libraries._
 ## Layouts
 
 Each slide can include a custom layout around its content,
-which can be used as a *template* for visually differentiating slides.
+which can be used as a _template_ for visually differentiating slides.
 
 ```js
 // example Layout.js
@@ -168,7 +168,7 @@ or style child elements with CSS-in-JS.
 
 ## Presenter Mode
 
-Press `Option + P` to toggle *Presenter Mode*,
+Press `Option + P` to toggle _Presenter Mode_,
 which will show a preview of the next slide, a timer, and speaker notes.
 
 ![presenter mode screenshot](docs/images/presenter-mode.png)
@@ -178,13 +178,13 @@ and it will stay in sync with the other window.
 
 ## Keyboard Shortcuts
 
-| Key         | Description                                  |
-| ----------- | -------------------------------------------- |
-| Left Arrow, Page Up, Shift + Space  | Go to previous slide (or step in [Steps][]) |
-| Right Arrow, Page Down, Space | Go to next slide (or step in [Steps][])     |
-| Option + P  | Toggle [Presenter Mode](#presenter-mode)     |
-| Option + O  | Toggle Overview Mode
-| Option + G  | Toggle Grid Mode
+| Key                                | Description                                 |
+| ---------------------------------- | ------------------------------------------- |
+| Left Arrow, Page Up, Shift + Space | Go to previous slide (or step in [Steps][]) |
+| Right Arrow, Page Down, Space      | Go to next slide (or step in [Steps][])     |
+| Option + P                         | Toggle [Presenter Mode](#presenter-mode)    |
+| Option + O                         | Toggle Overview Mode                        |
+| Option + G                         | Toggle Grid Mode                            |
 
 [steps]: docs/components.md#steps
 
@@ -213,7 +213,6 @@ and it will stay in sync with the other window.
 [harry wolff]: https://mobile.twitter.com/hswolff
 [ks-egghead]: https://egghead.io/lessons/javascript-build-a-custom-provider-component-for-mdx-deck
 [kyle shevlin]: https://twitter.com/kyleshevlin
-
 
 ## Examples
 
@@ -257,6 +256,7 @@ The following examples will open in CodeSandbox.
 [theme ui]: https://theme-ui.com
 
 <!-- examples -->
+
 [design-systems-react]: https://github-ds.now.sh/#0
 [brazil-now]: https://braziljs.now.sh
 [simplify-react]: https://simply-react.netlify.com/#0

--- a/packages/mdx-deck/package.json
+++ b/packages/mdx-deck/package.json
@@ -2,9 +2,7 @@
   "name": "mdx-deck",
   "version": "4.1.1",
   "description": "MDX-based presentation decks",
-  "bin": {
-    "mdx-deck": "./cli.js"
-  },
+  "bin": "./cli.js",
   "main": "index.js",
   "type": "module",
   "scripts": {
@@ -30,5 +28,8 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
   },
-  "gitHead": "13d00b47780424cc3b52d38ad6f19e99d007c06a"
+  "gitHead": "13d00b47780424cc3b52d38ad6f19e99d007c06a",
+  "engines": {
+    "node": ">=22"
+  }
 }

--- a/packages/starter/package.json
+++ b/packages/starter/package.json
@@ -16,5 +16,8 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
   },
-  "gitHead": "36497d5571f1f354261b9f72f1f67e23c07bc22e"
+  "gitHead": "36497d5571f1f354261b9f72f1f67e23c07bc22e",
+  "engines": {
+    "node": ">=22"
+  }
 }

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -9,5 +9,8 @@
     "lodash.merge": "^4.6.1",
     "react-syntax-highlighter": "^12.2.1"
   },
-  "gitHead": "13d00b47780424cc3b52d38ad6f19e99d007c06a"
+  "gitHead": "13d00b47780424cc3b52d38ad6f19e99d007c06a",
+  "engines": {
+    "node": ">=22"
+  }
 }

--- a/packages/website-pdf/package.json
+++ b/packages/website-pdf/package.json
@@ -13,5 +13,8 @@
     "mkdirp": "^1.0.3",
     "puppeteer": "^24.16.0"
   },
-  "gitHead": "13d00b47780424cc3b52d38ad6f19e99d007c06a"
+  "gitHead": "13d00b47780424cc3b52d38ad6f19e99d007c06a",
+  "engines": {
+    "node": ">=22"
+  }
 }

--- a/templates/basic/README.md
+++ b/templates/basic/README.md
@@ -2,6 +2,8 @@
 
 This was generated with [mdx-deck][]'s `npm init deck` command.
 
+Requires Node.js v22 or higher.
+
 ## Development
 
 To run the presentation deck in development mode:

--- a/templates/basic/package.json
+++ b/templates/basic/package.json
@@ -9,5 +9,8 @@
   },
   "devDependencies": {
     "mdx-deck": "^4.1.1"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }


### PR DESCRIPTION
## Summary
- require Node.js v22+ in root and all workspace packages
- document Node 22 requirement in README and template

## Testing
- `yarn test` *(fails: gatsby develop exited unexpectedly)*
- `yarn jest`


------
https://chatgpt.com/codex/tasks/task_e_6893c06263b8832194b06f8c68d5c903